### PR TITLE
Removed password from the console on startup

### DIFF
--- a/src/PocketDockConsole/SocksServer.php
+++ b/src/PocketDockConsole/SocksServer.php
@@ -34,7 +34,6 @@ class SocksServer extends \Thread {
         $this->loadPaths = array_reverse($loadPaths);
         $this->start(PTHREADS_INHERIT_ALL & ~PTHREADS_INHERIT_CLASSES);
         $this->log("Started SocksServer on " . $this->host . ":" . $this->port);
-        $this->log("Authentication password is: " . $this->password);
         if ($this->password === "PocketDockRules!") {
             $this->log("You are using the default password! Please change the password in config.yml");
         }


### PR DESCRIPTION
I find this a huge security risk, broadcasting the password in the console when the server starts. It's bad enough the password is in plain text in the config file... Couldn't you prompt for a password on the first run and hash it and store the hash in the config or even a different file??
